### PR TITLE
Rejig config defaults for external use

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ env | default | behavior
 --- | --- | ---
 `KC_KUBE_PS1_TOGGLE` | 1 | Whether to turn the kube-ps1 prompt display on and off automatically based on whether kc has set an active context
 `KC_TAB_COLOR` | 1 | Whether to change the iTerm2 tab color automatically based on the context name (e.g. red for `prod` anywhere in the context name)
-`KC_EKS_ALIASES` | 1 | Whether to alias `kubectl` and `helm` to use AWS IAM authentication via `aws-vault`
+`KC_EKS_ALIASES` | 0 | Whether to alias `kubectl` and `helm` to use AWS IAM authentication via `aws-vault`
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ env | default | behavior
 --- | --- | ---
 `KC_KUBE_PS1_TOGGLE` | 1 | Whether to turn the kube-ps1 prompt display on and off automatically based on whether kc has set an active context
 `KC_ITERM_USER_VAR` | 1 | Whether to set the iTerm2 user variables `kubecontext`/`kubens` to the current context/namespace when it changes
-`KC_ITERM_TAB_COLOR` | 1 | Whether to change the iTerm2 tab color automatically based on the context name (e.g. red for `prod` anywhere in the context name)
+`KC_ITERM_TAB_COLOR` | 0 | Whether to change the iTerm2 tab color automatically based on the context name (e.g. red for `prod` anywhere in the context name)
 `KC_EKS_ALIASES` | 0 | Whether to alias `kubectl` and `helm` to use AWS IAM authentication via `aws-vault`
 `KC_EKS_ASSUME_ROLE_TTL` | 60m | Passed to `aws-vault` as `--assume-role-ttl`
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ env | default | behavior
 `KC_KUBE_PS1_TOGGLE` | 1 | Whether to turn the kube-ps1 prompt display on and off automatically based on whether kc has set an active context
 `KC_TAB_COLOR` | 1 | Whether to change the iTerm2 tab color automatically based on the context name (e.g. red for `prod` anywhere in the context name)
 `KC_EKS_ALIASES` | 0 | Whether to alias `kubectl` and `helm` to use AWS IAM authentication via `aws-vault`
+`KC_EKS_ASSUME_ROLE_TTL` | 60m | Passed to `aws-vault` as `--assume-role-ttl`
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ like `helm` to work with EKS via IAM authentication, by making use of
 env | default | behavior
 --- | --- | ---
 `KC_KUBE_PS1_TOGGLE` | 1 | Whether to turn the kube-ps1 prompt display on and off automatically based on whether kc has set an active context
-`KC_TAB_COLOR` | 1 | Whether to change the iTerm2 tab color automatically based on the context name (e.g. red for `prod` anywhere in the context name)
+`KC_ITERM_TAB_COLOR` | 1 | Whether to change the iTerm2 tab color automatically based on the context name (e.g. red for `prod` anywhere in the context name)
 `KC_EKS_ALIASES` | 0 | Whether to alias `kubectl` and `helm` to use AWS IAM authentication via `aws-vault`
 `KC_EKS_ASSUME_ROLE_TTL` | 60m | Passed to `aws-vault` as `--assume-role-ttl`
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ accidentally run against the production cluster in a different shell where your
 it works around the lack of a [KUBECONTEXT](https://github.com/kubernetes/kubernetes/issues/27308)
 environment variable.)
 
-Because it's a shell function, not an executable, it can also alias common tools
-like `helm` to work with EKS via IAM authentication, by making use of
-[aws-vault](https://github.com/99designs/aws-vault)
-
 ## Usage
 
 ```
@@ -58,6 +54,17 @@ like `helm` to work with EKS via IAM authentication, by making use of
   cp completion/kc.zsh ~/.oh-my-zsh/completions/
   ```
 
+## Other Features
+
+`kc` has a few extra features for users of iTerm2 and/or EKS:
+
+- `kc` can alias common tools like `helm`/`kubectl` to work with EKS via IAM
+  authentication, by making use of [aws-vault](https://github.com/99designs/aws-vault) -
+  to enable this feature, set `KC_EKS_ALIASES=1`
+- Under iTerm2 `kc` can optionally change tab color depending on the context name
+- Under iTerm2 `kc` will set the `kubecontext` and `kubens` user variables - these
+  can be used to put the current context/namespace in the status bar
+
 ## Configuration
 
 `kc` supports the following environment variables that can alter its behavior:
@@ -65,6 +72,7 @@ like `helm` to work with EKS via IAM authentication, by making use of
 env | default | behavior
 --- | --- | ---
 `KC_KUBE_PS1_TOGGLE` | 1 | Whether to turn the kube-ps1 prompt display on and off automatically based on whether kc has set an active context
+`KC_ITERM_USER_VAR` | 1 | Whether to set the iTerm2 user variables `kubecontext`/`kubens` to the current context/namespace when it changes
 `KC_ITERM_TAB_COLOR` | 1 | Whether to change the iTerm2 tab color automatically based on the context name (e.g. red for `prod` anywhere in the context name)
 `KC_EKS_ALIASES` | 0 | Whether to alias `kubectl` and `helm` to use AWS IAM authentication via `aws-vault`
 `KC_EKS_ASSUME_ROLE_TTL` | 60m | Passed to `aws-vault` as `--assume-role-ttl`

--- a/kc-init.sh
+++ b/kc-init.sh
@@ -32,14 +32,17 @@ if [[ "${KC_EKS_ALIASES:-0}" -eq 1 ]]; then
 fi
 
 # Colors for iterm2 tabs
-if [[ "${TERM_PROGRAM}" == "iTerm.app" && ${KC_TAB_COLOR:-1} -eq 1 ]]; then
-  function __kc_tab_color() {
-    echo -ne "\033]6;1;bg;red;brightness;${1:-}\a\033]6;1;bg;green;brightness;${2:-}\a\033]6;1;bg;blue;brightness;${3:-}\a"
-  }
+if [[ "${TERM_PROGRAM}" == "iTerm.app" ]]; then
+  if [[ ${KC_ITERM_TAB_COLOR:-1} -eq 1 ]]; then
+    function __kc_tab_color() {
+      echo -ne "\033]6;1;bg;red;brightness;${1:-}\a\033]6;1;bg;green;brightness;${2:-}\a\033]6;1;bg;blue;brightness;${3:-}\a"
+    }
 
-  function __kc_tab_color_reset() {
-    echo -ne "\033]6;1;bg;*;default\a"
-  }
+    function __kc_tab_color_reset() {
+      echo -ne "\033]6;1;bg;*;default\a"
+    }
+  fi
+
 fi
 
 # Announce the context change
@@ -51,21 +54,23 @@ function __kc_on() {
     fi
   fi
 
-  if [[ "${TERM_PROGRAM}" == "iTerm.app" && ${KC_TAB_COLOR:-1} -eq 1 ]]; then
-    case "${__kc_context}" in
-      *prod*)
-        __kc_tab_color 251 107  98 # red
-        ;;
-      *staging*)
-        __kc_tab_color  95 164 248 # blue
-        ;;
-      *docker*)
-        __kc_tab_color 181 215  73 # green
-        ;;
-      *)
-        __kc_tab_color_reset
-        ;;
-    esac
+  if [[ "${TERM_PROGRAM}" == "iTerm.app" ]]; then
+    if [[ ${KC_ITERM_TAB_COLOR:-1} -eq 1 ]]; then
+      case "${__kc_context}" in
+        *prod*)
+          __kc_tab_color 251 107  98 # red
+          ;;
+        *staging*)
+          __kc_tab_color  95 164 248 # blue
+          ;;
+        *docker*)
+          __kc_tab_color 181 215  73 # green
+          ;;
+        *)
+          __kc_tab_color_reset
+          ;;
+      esac
+    fi
   fi
 
   if [[ -z "${__kc_ns}" ]]; then

--- a/kc-init.sh
+++ b/kc-init.sh
@@ -43,6 +43,11 @@ if [[ "${TERM_PROGRAM}" == "iTerm.app" ]]; then
     }
   fi
 
+  if [[ ${KC_ITERM_USER_VAR:-1} -eq 1 ]]; then
+    function __kc_user_var() {
+      printf "\033]1337;SetUserVar=%s=%s\007" "$1" "$(printf "%s" "$2" | base64 | tr -d '\n')"
+    }
+  fi
 fi
 
 # Announce the context change
@@ -71,6 +76,11 @@ function __kc_on() {
           ;;
       esac
     fi
+
+    if [[ ${KC_ITERM_USER_VAR:-1} -eq 1 ]]; then
+      __kc_user_var kubecontext "${__kc_context}"
+      __kc_user_var kubens "${__kc_ns}"
+    fi
   fi
 
   if [[ -z "${__kc_ns}" ]]; then
@@ -89,8 +99,15 @@ function __kc_off() {
     fi
   fi
 
-  if [[ "${TERM_PROGRAM}" == "iTerm.app" && ${KC_TAB_COLOR:-1} -eq 1 ]]; then
-    __kc_tab_color_reset
+  if [[ "${TERM_PROGRAM}" == "iTerm.app" ]]; then
+    if [[ ${KC_ITERM_TAB_COLOR:-0} -eq 1 ]]; then
+      __kc_tab_color_reset
+    fi
+
+    if [[ ${KC_ITERM_USER_VAR:-1} -eq 1 ]]; then
+      __kc_user_var kubecontext ""
+      __kc_user_var kubens ""
+    fi
   fi
 }
 

--- a/kc-init.sh
+++ b/kc-init.sh
@@ -33,7 +33,7 @@ fi
 
 # Colors for iterm2 tabs
 if [[ "${TERM_PROGRAM}" == "iTerm.app" ]]; then
-  if [[ ${KC_ITERM_TAB_COLOR:-1} -eq 1 ]]; then
+  if [[ ${KC_ITERM_TAB_COLOR:-0} -eq 1 ]]; then
     function __kc_tab_color() {
       echo -ne "\033]6;1;bg;red;brightness;${1:-}\a\033]6;1;bg;green;brightness;${2:-}\a\033]6;1;bg;blue;brightness;${3:-}\a"
     }
@@ -60,7 +60,7 @@ function __kc_on() {
   fi
 
   if [[ "${TERM_PROGRAM}" == "iTerm.app" ]]; then
-    if [[ ${KC_ITERM_TAB_COLOR:-1} -eq 1 ]]; then
+    if [[ ${KC_ITERM_TAB_COLOR:-0} -eq 1 ]]; then
       case "${__kc_context}" in
         *prod*)
           __kc_tab_color 251 107  98 # red

--- a/kc-init.sh
+++ b/kc-init.sh
@@ -24,7 +24,7 @@ elif test -n "$BASH_VERSION"; then
   fi
 fi
 
-if [[ "${KC_EKS_ALIASES:-1}" -eq 1 ]]; then
+if [[ "${KC_EKS_ALIASES:-0}" -eq 1 ]]; then
   if ! hash aws-vault > /dev/null 2>&1; then
       echo "Expected aws-vault to be on PATH; kc is configured for EKS" >&2
       exit 1
@@ -143,7 +143,7 @@ function kc() {
 
     export KUBECONFIG="${config}"
 
-    if [[ "${KC_EKS_ALIASES:-1}" -eq 1 ]]; then
+    if [[ "${KC_EKS_ALIASES:-0}" -eq 1 ]]; then
       # shellcheck disable=SC2139
       alias kubectl="aws-vault exec --assume-role-ttl=60m ${__kc_context} -- kubectl"
       # shellcheck disable=SC2139
@@ -160,7 +160,7 @@ function kc() {
     fi
 
     # Unalias common tools
-    if [[ "${KC_EKS_ALIASES:-1}" -eq 1 ]]; then
+    if [[ "${KC_EKS_ALIASES:-0}" -eq 1 ]]; then
       unalias kubectl 2>/dev/null
       unalias helm 2>/dev/null
     fi

--- a/kc-init.sh
+++ b/kc-init.sh
@@ -144,10 +144,12 @@ function kc() {
     export KUBECONFIG="${config}"
 
     if [[ "${KC_EKS_ALIASES:-0}" -eq 1 ]]; then
+      assume_role_ttl="${KC_EKS_ASSUME_ROLE_TTL:-60m}"
+
       # shellcheck disable=SC2139
-      alias kubectl="aws-vault exec --assume-role-ttl=60m ${__kc_context} -- kubectl"
+      alias kubectl="aws-vault exec --assume-role-ttl=${assume_role_ttl} ${__kc_context} -- kubectl"
       # shellcheck disable=SC2139
-      alias helm="aws-vault exec --assume-role-ttl=60m ${__kc_context} -- helm"
+      alias helm="aws-vault exec --assume-role-ttl=${assume_role_ttl} ${__kc_context} -- helm"
     fi
 
     __kc_on


### PR DESCRIPTION
`kc` is now open-sourced, so it's a good point to review the default configuration and make sure it's streamlined for other users.

- Disabled `KC_EKS_ALIASES` and `KC_ITERM_TAB_COLOR` by default (they're now opt-in)
- Added `KC_ITERM_USER_VAR`, which sets user variables in iTerm e.g. for display in a Status Bar component
  - This defaults to on, because it you'd need to configure further for it to actually show up anywhere
- Renamed iTerm2 configuration values to include `_ITERM_` in the config name
- Added `KC_EKS_ASSUME_ROLE_TTL` with a default of `60m` (wasn't previously configurable)